### PR TITLE
add ARG commit to build against specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:2
 MAINTAINER Philipp Schmitt <philipp@schmitt.co>
 
 ARG repo=devel
+ARG commit
 
 RUN apt-get update && \
     apt-get install -y git && \
@@ -11,7 +12,7 @@ RUN apt-get update && \
     ln -s /config /home/weboob/.config/weboob && \
     ln -s /data /home/weboob/.local/share/weboob && \
     chown -R weboob:weboob ~weboob /config /data && \
-    pip install prettytable git+https://git.weboob.org/weboob/${repo}.git && \
+    pip install prettytable git+https://git.weboob.org/weboob/${repo}.git${commit} && \
     apt-get remove --purge -y git && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -20,5 +21,4 @@ USER weboob
 WORKDIR "/config"
 VOLUME ["/config", "/data"]
 
-# ENTRYPOINT ["/usr/local/bin/weboob"]
 CMD ["weboob"]


### PR DESCRIPTION
Hi,
With this new variable, I can build the Docker image for a given version, like:
docker build --build-arg repo=stable --build-arg commit=@1.2 .

So I'm sure I will be able to build even if weboob-1.3 breaks everything